### PR TITLE
Add CI workflow for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run setup script
+        run: bash setup.sh
+      - name: Run tests
+        run: |
+          source .venv/bin/activate
+          pytest -q


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running setup and tests on Python 3.10/3.11

## Testing
- `bash setup.sh` *(fails: Could not open requirements file: backend/requirements.txt)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a22563834883278a05d224d92f6c23